### PR TITLE
Add needed api_key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ script:
 - bundle exec rspec
 deploy:
   provider: heroku
-  api_key: e301a7d3-6db0-4a31-b6fe-39f101780cfd
+  api_key:
+    secure: Q7esPqDpn0SmwYmvJgwcL+zt3veaOzoSjC3skCBVucNHt6U27yGnN986pYuNulIN9NvZdd6q2WBpzAulZHWuBmnNuay4gGJ5Eb+mmCJoHkpPlkq2xoqGNQqRiovcd3M50gknlFqHmBRJfuLWf6VkUAdg5X06KV2rtUHEoCBJCVZb8IOfC9kzddXC9KwNwX8v5QPEuUv/jBAPxgpIRy/ICTYGMRWZwPB9XuZVzGO9eQYfm7FZ5tIvUa5xH84wm2DYJXZNkM+v410voxbeiyGe+vugRaxIwf6BmRuyEcvKAQkO1jW9yVKpJXB50CNDBtanI1oHl5Ou+cEBFSmIhm2ZGp8NvfRaBKXOomOoQJ2IWL9BodpopPYvV+5Sz6BFrO5DUUYg+oOOOLSx4B4iZaaOdthVB+MBfNcfKAUOUI8SeBCnAz5ED6KOl213Nqsgm3NC/uJ9H7OGOQtvx7klV9ei3WbrwSm0aKFQJzu7ive41RwGm0efdd9yPukibYJakpiTKesDPb97gsXck1a52YLV6UzQaOW6Y+dGrwJLqW4QX9aTgBjHu3FwrrB3ASBqQ6/a/KaXo8/2OJtt0YdThPb2V6quywbgV4tuVOT+ftQMKWwqFAU9oa7EzTqbZZCnBi73PNq08VVJz6OIRS6I+iCaKc55INhecsmhi+/tPTHgGRM=
   app: quiet-mountain-79102
-  run: rails db:migrate
+  on:
+    repo: lcpulzone/viewing_party
+    branch: main
+  skip_cleanup: 'true'


### PR DESCRIPTION
# User story worked on: Heroku/Travis

- [x] Completed
- [ ] In progress: tests passing
- [ ] In progress: tests not passing
- [ ] Help needed

# Description of work done: Followed steps laid out by a peer in our codehelp slack channel.  Needed to install Travis CI Client, then add in a personal access token from Github, then insert a secure API key via a command found on https://github.com/travis-ci/travis-ci/issues/8250.  This allowed us to then type the command travis setup heroku --pro --force.  After this we were able to get tie Heroku and Travis together.


## Additional Notes:
